### PR TITLE
fix: correct Redis error message and update MongoDB URI formatting

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -26,11 +26,11 @@ async fn main() {
 
     let config = load_config();
     let cache_addr = format!("{}:{}", config.cache_url, config.cache_port);
-    // let db_addr = format!(
-    //     "{}{}:{}@{}:{}",
-    //     config.db_protocol, config.db_user, config.db_password, config.db_url, config.db_port
-    // );
-    let db_addr = format!("{}{}:{}", config.db_protocol, config.db_url, config.db_port);
+    let db_addr = format!(
+        "{}{}:{}@{}:{}",
+        config.db_protocol, config.db_user, config.db_password, config.db_url, config.db_port
+    );
+    //let db_addr = format!("{}{}:{}", config.db_protocol, config.db_url, config.db_port);
 
     info!("Connecting to Redis at {}", cache_addr);
     info!("Connecting to MongoDB at {}", db_addr);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -68,7 +68,7 @@ pub async fn construct_mongodb_conn(url: &str) -> Arc<Mutex<MongoDbConn>> {
 pub async fn construct_redis_conn(url: &str) -> Arc<Mutex<RedisCacheConn>> {
     let redis_conn = match RedisCacheConn::init(url).await {
         Ok(conn) => conn,
-        Err(e) => panic!("Failed to connect to MongoDB with error: {}", e),
+        Err(e) => panic!("Failed to connect to Redis with error: {}", e),
     };
 
     Arc::new(Mutex::new(redis_conn))


### PR DESCRIPTION
- Correct Redis connection error message in `src/utils.rs`
- Update `db_addr` formatting in `src/main.rs` to include user and password in the MongoDB URI

This improves error clarity and aligns the MongoDB connection string with credentials when provided.